### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ wget -O docker-compose.yml https://raw.githubusercontent.com/AmRo045/OutlineAdmi
 ```
 
 ```bash
-docker-compose up -d
+docker compose up -d
 ```
 
 ### Installation - NodeJS


### PR DESCRIPTION
## Changes:
Replaced `docker-compose up -d` with `docker compose up -d`, following the newer Docker CLI syntax.

## Reason for Change:
Docker has transitioned from docker-compose (a separate binary) to docker compose (a built-in subcommand in Docker CLI).