### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,9 @@ on:
       - access.sh
       - README.md
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/AmRo045/OutlineAdmin/security/code-scanning/2](https://github.com/AmRo045/OutlineAdmin/security/code-scanning/2)

To address the flagged issue, you should explicitly add a `permissions` block to the workflow YAML. The best place is at the root level, right after the `name` (and optionally after `on`), so it sets a default for all jobs. The minimal required permission for the steps shown is `contents: read`, which is sufficient for checking out the code and typical build steps. This avoids granting unneeded write access. No existing functionality is changed because none of the current steps require more than this permission. Only edit the `.github/workflows/build.yml` file, inserting:

```yaml
permissions:
  contents: read
```

as described.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
